### PR TITLE
Migrate blocks from Twitter API Standard v1.1 to v2

### DIFF
--- a/src/app/share-report/share-report.component.html
+++ b/src/app/share-report/share-report.component.html
@@ -76,6 +76,12 @@
         <div class="card-body">
           Block or mute the accounts listed in your report. <a href="https://help.twitter.com/en/using-twitter#blocking-and-muting" target="_blank" rel="noopener">Learn more</a>
         </div>
+        <hr>
+        <div class="card-body small-text">
+          Only 50 accounts can be blocked every 15 minutes. We recommend dividing blocks across
+          multiple reports.
+        </div>
+
 
         <app-dropdown-button
             class="twitter-actions-button"

--- a/src/app/share-report/share-report.component.spec.ts
+++ b/src/app/share-report/share-report.component.spec.ts
@@ -77,6 +77,7 @@ describe('ShareReportComponent', () => {
         id_str: 'a',
         text: 'your mother was a hamster',
         date: new Date(),
+        authorId: '1234567891011',
         authorScreenName: 'testing1',
         in_reply_to_status_id: '123',
       },
@@ -89,6 +90,7 @@ describe('ShareReportComponent', () => {
         id_str: 'b',
         text: 'and your father smelt of elderberries',
         date: new Date(),
+        authorId: '1234567891012',
         authorScreenName: 'testing2',
       },
       scores: {
@@ -360,8 +362,8 @@ describe('ShareReportComponent', () => {
       )
     ).toBeFalsy();
     expect(mockTwitterApiService.blockUsers).not.toHaveBeenCalledWith([
-      'testing1',
-      'testing2',
+      { id_str: '1234567891011', screen_name: 'testing1' },
+      { id_str: '1234567891012', screen_name: 'testing2' },
     ]);
     mockTwitterApiService.blockUsers.calls.reset();
 
@@ -382,8 +384,8 @@ describe('ShareReportComponent', () => {
       )
     ).toBeFalsy();
     expect(mockTwitterApiService.blockUsers).toHaveBeenCalledWith([
-      'testing1',
-      'testing2',
+      { id_str: '1234567891011', screen_name: 'testing1' },
+      { id_str: '1234567891012', screen_name: 'testing2' },
     ]);
     mockTwitterApiService.blockUsers.calls.reset();
 
@@ -402,8 +404,8 @@ describe('ShareReportComponent', () => {
       )
     ).toBeTruthy();
     expect(mockTwitterApiService.blockUsers).toHaveBeenCalledWith([
-      'testing1',
-      'testing2',
+      { id_str: '1234567891011', screen_name: 'testing1' },
+      { id_str: '1234567891012', screen_name: 'testing2' },
     ]);
   }));
 

--- a/src/app/twitter_api.service.ts
+++ b/src/app/twitter_api.service.ts
@@ -28,6 +28,7 @@ import {
   HideRepliesTwitterResponse,
   MuteTwitterUsersRequest,
   MuteTwitterUsersResponse,
+  TwitterUser,
 } from '../common-types';
 import { OauthApiService } from './oauth_api.service';
 
@@ -96,7 +97,7 @@ export class TwitterApiService {
     return fullResponse;
   }
 
-  blockUsers(users: string[]): Observable<BlockTwitterUsersResponse> {
+  blockUsers(users: TwitterUser[]): Observable<BlockTwitterUsersResponse> {
     const request: Partial<BlockTwitterUsersRequest> = { users };
     const credential = this.oauthApiService.getTwitterOauthCredential();
 

--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -26,6 +26,7 @@ export interface SocialMediaItem {
   text: string;
   date: Date;
   url?: string;
+  authorId?: string;
   authorName?: string;
   authorScreenName?: string;
   authorUrl?: string;
@@ -89,12 +90,14 @@ export interface GetTweetsResponse {
 
 export interface BlockTwitterUsersRequest {
   credential: firebase.auth.OAuthCredential;
-  users: string[];
+  users: TwitterUser[];
 }
 
 export interface BlockTwitterUsersResponse {
   error?: string;
   failedScreennames?: string[]; // Twitter screen names
+  numQuotaFailures?: number;
+  numOtherFailures?: number;
 }
 
 export interface MuteTwitterUsersRequest {
@@ -169,7 +172,7 @@ export interface TweetObject {
   source?: string;
 }
 
-interface TwitterUser {
+export interface TwitterUser {
   id_str: string;
   screen_name: string;
 

--- a/src/server/middleware/twitter.middleware.ts
+++ b/src/server/middleware/twitter.middleware.ts
@@ -75,15 +75,15 @@ export async function getTweets(
 export async function blockTwitterUsers(
   req: Request,
   res: Response,
-  apiCredentials: TwitterApiCredentials
+  credentials: TwitterApiCredentials
 ) {
-  if (!standardApiCredentialsAreValid(apiCredentials)) {
+  if (!standardApiCredentialsAreValid(credentials)) {
     res.send(new Error('Invalid Twitter Standard API credentials'));
     return;
   }
 
   const request = req.body as BlockTwitterUsersRequest;
-  const response = await blockUsers(apiCredentials, request);
+  const response = await blockUsers(credentials, request);
   if (response.error) {
     // All block API requests failed. Send an error.
     res.status(500).send(response);
@@ -133,30 +133,47 @@ export async function hideTwitterReplies(
 }
 
 async function blockUsers(
-  apiCredentials: TwitterApiCredentials,
+  credentials: TwitterApiCredentials,
   request: BlockTwitterUsersRequest
 ): Promise<BlockTwitterUsersResponse> {
-  const client = createAxiosInstance(apiCredentials, request.credential);
-  const requestUrl = 'https://api.twitter.com/1.1/blocks/create.json';
+  const client = createAxiosInstance(credentials, request.credential);
   const response: BlockTwitterUsersResponse = {};
+  const id = getUserIdFromCredential(request.credential);
+  if (!id) {
+    response.error = 'Missing Twitter user ID in access token';
+    return response;
+  }
+  let quotaExhaustedErrors = 0;
+  let otherErrors = 0;
   const requests = request.users.map((user) =>
     client
       .post<BlockTwitterUsersResponse>(
-        requestUrl,
-        {},
-        { params: { screen_name: user } }
+        `https://api.twitter.com/2/users/${id}/blocking`,
+        { target_user_id: user.id_str }
       )
-      .catch((e) => {
-        console.error(`Unable to block Twitter user: @${user} because ${e}`);
+      .catch((e: AxiosError) => {
+        if (
+          e.response?.status === 429 ||
+          e.response?.statusText.includes('Too Many Requests')
+        ) {
+          quotaExhaustedErrors += 1;
+        } else {
+          otherErrors += 1;
+        }
+        console.error(
+          `Unable to block Twitter user @${user.screen_name} because ${e}`
+        );
         response.failedScreennames = [
           ...(response.failedScreennames ?? []),
-          user,
+          user.screen_name,
         ];
       })
   );
 
   await Promise.all(requests);
-  if (request.users.length === response.failedScreennames?.length) {
+  response.numQuotaFailures = quotaExhaustedErrors;
+  response.numOtherFailures = otherErrors;
+  if (otherErrors == request.users.length) {
     response.error = 'Unable to block Twitter users';
   }
   return response;
@@ -358,6 +375,7 @@ function parseTweet(tweetObject: TweetObject): Tweet {
     tweet.date = new Date(tweetObject.created_at);
   }
   if (tweetObject.user) {
+    tweet.authorId = tweetObject.user.id_str;
     tweet.authorName = tweetObject.user.name;
     tweet.authorScreenName = tweetObject.user.screen_name;
     tweet.authorUrl = `https://twitter.com/${tweetObject.user.screen_name}`;
@@ -368,4 +386,10 @@ function parseTweet(tweetObject: TweetObject): Tweet {
     tweet.hasImage = true;
   }
   return tweet;
+}
+
+function getUserIdFromCredential(credential: firebase.auth.OAuthCredential) {
+  // The numeric part of the Twitter Access Token is the user ID.
+  const match = credential.accessToken?.match('[0-9]+');
+  return match && match.length ? match[0] : null;
 }

--- a/src/server/middleware/twitter.middleware.ts
+++ b/src/server/middleware/twitter.middleware.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { HttpStatusCode } from '@angular/common/http';
 import axios, { AxiosBasicCredentials, AxiosError, AxiosInstance } from 'axios';
 import addOAuthInterceptor from 'axios-oauth-1.0a';
 import { Request, Response } from 'express';
@@ -153,7 +154,7 @@ async function blockUsers(
       )
       .catch((e: AxiosError) => {
         if (
-          e.response?.status === 429 ||
+          e.response?.status === HttpStatusCode.TooManyRequests ||
           e.response?.statusText.includes('Too Many Requests')
         ) {
           quotaExhaustedErrors += 1;
@@ -226,7 +227,7 @@ async function hideReplies(
       .catch((e: AxiosError) => {
         console.error(`Unable to hide tweet ID: ${id} because ${e}`);
         if (
-          e.response?.status === 429 ||
+          e.response?.status === HttpStatusCode.TooManyRequests ||
           e.response?.statusText.includes('Too Many Requests')
         ) {
           quotaExhaustedErrors += 1;


### PR DESCRIPTION
v2 introduces a few changes, including:

- A new endpoint: `https://api.twitter.com/2/users/:id/blocking`, where `:id` is
  the ID of the requesting user.
- Different request parameters. Namely, v2 does not support `screen_name`, only
  `target_user_id`.
- Rate limiting to 50 requests per user per 15 minutes.

To accomodate these changes, we update interfaces, request logic, and the UI.
The error logic and UI messaging mimics our implementation for hiding Twitter
replies for consistency.