### PR TITLE
Migrate mutes from Twitter API Standard v1.1 to v2

### DIFF
--- a/src/app/dropdown-button/dropdown-button.component.ts
+++ b/src/app/dropdown-button/dropdown-button.component.ts
@@ -53,20 +53,19 @@ export interface ActionButtonOption {
 })
 export class DropdownButtonComponent implements OnChanges {
   @Output() clickActionOption = new EventEmitter<ActionButtonOption>();
+  @Output() selectActionOptionEvent = new EventEmitter<ActionButtonOption>();
 
   @Input() actionOptions: ActionButtonOption[] = [];
   @Input() selectedActionOptionIndex = 0;
-  selectedActionOption: ActionButtonOption = this.actionOptions[
-    this.selectedActionOptionIndex
-  ];
+  selectedActionOption: ActionButtonOption =
+    this.actionOptions[this.selectedActionOptionIndex];
   @Input() actions: ReportAction[] = [];
   @Input() dropdownButtonAriaLabel = '';
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['actionOptions'] || changes['selectedActionOptionIndex']) {
-      this.selectedActionOption = this.actionOptions[
-        this.selectedActionOptionIndex
-      ];
+      this.selectedActionOption =
+        this.actionOptions[this.selectedActionOptionIndex];
     }
   }
 
@@ -88,7 +87,7 @@ export class DropdownButtonComponent implements OnChanges {
     private readonly actionService: ActionService,
     private readonly scrollStrategyOptions: ScrollStrategyOptions
   ) {
-    this.actionService.actionState.subscribe(state => {
+    this.actionService.actionState.subscribe((state) => {
       if (state.action === this.selectedActionOption.action) {
         this.actionInProgress = state.inProgress;
       }
@@ -132,6 +131,7 @@ export class DropdownButtonComponent implements OnChanges {
     }
     this.selectedActionOption = option;
     this.toggleActionOptionsMenu(false);
+    this.selectActionOptionEvent.next(this.selectedActionOption);
   }
 
   getActionOptionDropdownDisabled(): boolean {
@@ -153,7 +153,7 @@ export class DropdownButtonComponent implements OnChanges {
  * the same <a> element for both downloading CSV/PDF and as a print button.
  */
 @Directive({
-  selector: '[hrefOnlyDownload]',  // eslint-disable-line  @angular-eslint/directive-selector
+  selector: '[hrefOnlyDownload]', // eslint-disable-line  @angular-eslint/directive-selector
 })
 export class HrefOnlyDownloadDirective implements OnChanges {
   @Input() downloadRef = '';

--- a/src/app/dropdown-button/dropdown-button.component.ts
+++ b/src/app/dropdown-button/dropdown-button.component.ts
@@ -131,7 +131,7 @@ export class DropdownButtonComponent implements OnChanges {
     }
     this.selectedActionOption = option;
     this.toggleActionOptionsMenu(false);
-    this.selectActionOptionEvent.next(this.selectedActionOption);
+    this.selectActionOptionEvent.emit(this.selectedActionOption);
   }
 
   getActionOptionDropdownDisabled(): boolean {

--- a/src/app/share-report/share-report.component.html
+++ b/src/app/share-report/share-report.component.html
@@ -78,11 +78,11 @@
         </div>
         <hr>
         <div class="card-body small-text">
-          <ng-container *ngIf="selectedTwitterAction == ReportAction.BLOCK_TWITTER">
+          <ng-container *ngIf="selectedTwitterAction === ReportAction.BLOCK_TWITTER">
             Only 50 accounts can be blocked every 15 minutes. We recommend dividing blocks across
             multiple reports.
           </ng-container>
-          <ng-container *ngIf="selectedTwitterAction == ReportAction.MUTE_TWITTER">
+          <ng-container *ngIf="selectedTwitterAction === ReportAction.MUTE_TWITTER">
             Only 50 accounts can be muted every 15 minutes. We recommend dividing mutes across
             multiple reports.
           </ng-container>

--- a/src/app/share-report/share-report.component.html
+++ b/src/app/share-report/share-report.component.html
@@ -78,8 +78,14 @@
         </div>
         <hr>
         <div class="card-body small-text">
-          Only 50 accounts can be blocked every 15 minutes. We recommend dividing blocks across
-          multiple reports.
+          <ng-container *ngIf="selectedTwitterAction == ReportAction.BLOCK_TWITTER">
+            Only 50 accounts can be blocked every 15 minutes. We recommend dividing blocks across
+            multiple reports.
+          </ng-container>
+          <ng-container *ngIf="selectedTwitterAction == ReportAction.MUTE_TWITTER">
+            Only 50 accounts can be muted every 15 minutes. We recommend dividing mutes across
+            multiple reports.
+          </ng-container>
         </div>
 
 
@@ -89,7 +95,8 @@
             dropdownButtonAriaLabel="Manage your audience on Twitter pop-up"
             [selectedActionOptionIndex]="selectedTwitterActionOptionIndex"
             [actions]="actions"
-            (clickActionOption)="handleClickActionOption($event)">
+            (clickActionOption)="handleClickActionOption($event)"
+            (selectActionOptionEvent)="handleSelectActionOption($event)">
         </app-dropdown-button>
 
       </div>

--- a/src/app/share-report/share-report.component.spec.ts
+++ b/src/app/share-report/share-report.component.spec.ts
@@ -435,8 +435,8 @@ describe('ShareReportComponent', () => {
       )
     ).toBeFalsy();
     expect(mockTwitterApiService.muteUsers).not.toHaveBeenCalledWith([
-      'testing1',
-      'testing2',
+      { id_str: '1234567891011', screen_name: 'testing1' },
+      { id_str: '1234567891012', screen_name: 'testing2' },
     ]);
     mockTwitterApiService.muteUsers.calls.reset();
 
@@ -457,8 +457,8 @@ describe('ShareReportComponent', () => {
       )
     ).toBeFalsy();
     expect(mockTwitterApiService.muteUsers).toHaveBeenCalledWith([
-      'testing1',
-      'testing2',
+      { id_str: '1234567891011', screen_name: 'testing1' },
+      { id_str: '1234567891012', screen_name: 'testing2' },
     ]);
     mockTwitterApiService.muteUsers.calls.reset();
 
@@ -478,8 +478,8 @@ describe('ShareReportComponent', () => {
       )
     ).toBeTruthy();
     expect(mockTwitterApiService.muteUsers).toHaveBeenCalledWith([
-      'testing1',
-      'testing2',
+      { id_str: '1234567891011', screen_name: 'testing1' },
+      { id_str: '1234567891012', screen_name: 'testing2' },
     ]);
   }));
 

--- a/src/app/share-report/share-report.component.ts
+++ b/src/app/share-report/share-report.component.ts
@@ -118,6 +118,8 @@ export class ShareReportComponent implements AfterViewInit {
     },
   ];
   selectedTwitterActionOptionIndex = 0;
+  selectedTwitterAction =
+    this.twitterActionOptions[this.selectedSaveOptionIndex].action;
 
   adblockErrorOpen = false;
 
@@ -201,16 +203,6 @@ export class ShareReportComponent implements AfterViewInit {
       });
   }
 
-  getUsersInReport(): string[] {
-    const comments = this.reportService.getCommentsForReport();
-    for (const comment of comments) {
-      if (!comment.item.authorScreenName) {
-        throw new Error('Missing author screenname for comment ' + comment);
-      }
-    }
-    return comments.map((comment) => comment.item.authorScreenName!);
-  }
-
   getTwitterUsersInReport(): TwitterUser[] {
     const comments = this.reportService.getCommentsForReport();
     for (const comment of comments) {
@@ -221,16 +213,27 @@ export class ShareReportComponent implements AfterViewInit {
         throw new Error('Missing author screenname for comment: ' + comment);
       }
     }
-    return comments.map(
+    const users = comments.map(
       (comment): TwitterUser => ({
         id_str: comment.item.authorId!,
         screen_name: comment.item.authorScreenName!,
       })
     );
+    // Remove duplicate user IDs.
+    const userIds = new Set();
+    return users.filter((user) => {
+      const hasId = userIds.has(user.id_str);
+      userIds.add(user.id_str);
+      return !hasId;
+    });
   }
 
   handleClickActionOption(option: ActionButtonOption) {
     this.addAction(option.action);
+  }
+
+  handleSelectActionOption(option: ActionButtonOption) {
+    this.selectedTwitterAction = option.action;
   }
 
   async addAction(action: ReportAction) {
@@ -368,24 +371,51 @@ export class ShareReportComponent implements AfterViewInit {
           if (result) {
             this.actionService.startAction(ReportAction.MUTE_TWITTER);
             await firstValueFrom(
-              this.twitterApiService.muteUsers(this.getUsersInReport())
+              this.twitterApiService.muteUsers(this.getTwitterUsersInReport())
             )
               .then((response) => {
-                const failures = response.failedScreennames;
-                if (failures?.length) {
+                const numQuotaFailures = response.numQuotaFailures;
+                const numOtherFailures = response.numOtherFailures;
+                if (numQuotaFailures) {
+                  // Some of the errors were quota issues, so we combine those
+                  // with any other issues to keep things straightforward for
+                  // users.
+                  const numFailures =
+                    numQuotaFailures + (numOtherFailures ?? 0);
                   this.dialog.open(ApiErrorDialogComponent, {
                     panelClass: 'api-error-dialog-container',
                     data: {
-                      failures,
                       message:
-                        'The following users could not be muted. These accounts ' +
-                        'may no longer be active or an unknown error may have ' +
-                        'occurred.',
-                      title: `${failures.length} ${
-                        failures.length === 1 ? 'user' : 'users'
+                        "Only 50 users can be muted every 15 minutes. If you'd " +
+                        'like to mute more than 50 users, you have a couple ' +
+                        'of options. You can either divide the users across ' +
+                        'multiple reports or you can resend the report to have ' +
+                        'up to another 50 users muted. Note that with both ' +
+                        "options you'll need to wait 15 minutes, remove the " +
+                        'previously submitted users, and select up to 50 ' +
+                        'additional new users.',
+                      title: `${numFailures} ${
+                        numFailures === 1 ? 'user' : 'users'
                       } could not be muted`,
                     },
                   });
+                } else if (numOtherFailures) {
+                  const failures = response.failedScreennames;
+                  if (failures?.length) {
+                    this.dialog.open(ApiErrorDialogComponent, {
+                      panelClass: 'api-error-dialog-container',
+                      data: {
+                        failures,
+                        message:
+                          'The following users could not be muted. These accounts ' +
+                          'may no longer be active or an unknown error may have ' +
+                          'occurred.',
+                        title: `${failures.length} ${
+                          failures.length === 1 ? 'user' : 'users'
+                        } could not be muted`,
+                      },
+                    });
+                  }
                 }
                 resolve(true);
               })

--- a/src/app/share-report/share-report.component.ts
+++ b/src/app/share-report/share-report.component.ts
@@ -119,7 +119,7 @@ export class ShareReportComponent implements AfterViewInit {
   ];
   selectedTwitterActionOptionIndex = 0;
   selectedTwitterAction =
-    this.twitterActionOptions[this.selectedSaveOptionIndex].action;
+    this.twitterActionOptions[this.selectedTwitterActionOptionIndex].action;
 
   adblockErrorOpen = false;
 
@@ -290,18 +290,17 @@ export class ShareReportComponent implements AfterViewInit {
                   // Some of the errors were quota issues, so we combine those
                   // with any other issues to keep things straightforward for
                   // users.
-                  const numFailures =
-                    numQuotaFailures + (numOtherFailures ?? 0);
+                  const numFailures = numQuotaFailures + (numOtherFailures ?? 0);
                   this.dialog.open(ApiErrorDialogComponent, {
                     panelClass: 'api-error-dialog-container',
                     data: {
                       message:
-                        "Only 50 users can be blocked every 15 minutes. If you'd " +
+                        'Only 50 users can be blocked every 15 minutes. If you\'d ' +
                         'like to block more than 50 users, you have a couple ' +
                         'of options. You can either divide the users across ' +
                         'multiple reports or you can resend the report to have ' +
                         'up to another 50 users blocked. Note that with both ' +
-                        "options you'll need to wait 15 minutes, remove the " +
+                        'options you\'ll need to wait 15 minutes, remove the ' +
                         'previously submitted users, and select up to 50 ' +
                         'additional new users.',
                       title: `${numFailures} ${
@@ -380,18 +379,17 @@ export class ShareReportComponent implements AfterViewInit {
                   // Some of the errors were quota issues, so we combine those
                   // with any other issues to keep things straightforward for
                   // users.
-                  const numFailures =
-                    numQuotaFailures + (numOtherFailures ?? 0);
+                  const numFailures = numQuotaFailures + (numOtherFailures ?? 0);
                   this.dialog.open(ApiErrorDialogComponent, {
                     panelClass: 'api-error-dialog-container',
                     data: {
                       message:
-                        "Only 50 users can be muted every 15 minutes. If you'd " +
+                        'Only 50 users can be muted every 15 minutes. If you\'d ' +
                         'like to mute more than 50 users, you have a couple ' +
                         'of options. You can either divide the users across ' +
                         'multiple reports or you can resend the report to have ' +
                         'up to another 50 users muted. Note that with both ' +
-                        "options you'll need to wait 15 minutes, remove the " +
+                        'options you\'ll need to wait 15 minutes, remove the ' +
                         'previously submitted users, and select up to 50 ' +
                         'additional new users.',
                       title: `${numFailures} ${
@@ -475,12 +473,12 @@ export class ShareReportComponent implements AfterViewInit {
                     panelClass: 'api-error-dialog-container',
                     data: {
                       message:
-                        "Only 50 replies can be hidden every 15 minutes. If you'd " +
+                        'Only 50 replies can be hidden every 15 minutes. If you\'d ' +
                         'like to hide more than 50 replies, you have a couple ' +
                         'of options. You can either divide the replies across ' +
                         'multiple reports or you can resend the report to have ' +
                         'up to another 50 replies removed. Note that with both ' +
-                        "options you'll need to wait 15 minutes, remove the " +
+                        'options you\'ll need to wait 15 minutes, remove the ' +
                         'previously submitted replies, and select up to 50 ' +
                         'additional new replies.',
                       title: `${numFailures} ${

--- a/src/app/twitter_api.service.ts
+++ b/src/app/twitter_api.service.ts
@@ -117,7 +117,7 @@ export class TwitterApiService {
       .pipe(take(1));
   }
 
-  muteUsers(users: string[]): Observable<MuteTwitterUsersResponse> {
+  muteUsers(users: TwitterUser[]): Observable<MuteTwitterUsersResponse> {
     const request: Partial<MuteTwitterUsersRequest> = { users };
     const credential = this.oauthApiService.getTwitterOauthCredential();
 

--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -102,12 +102,14 @@ export interface BlockTwitterUsersResponse {
 
 export interface MuteTwitterUsersRequest {
   credential: firebase.auth.OAuthCredential;
-  users: string[];
+  users: TwitterUser[];
 }
 
 export interface MuteTwitterUsersResponse {
   error?: string;
   failedScreennames?: string[]; // Twitter screen names
+  numQuotaFailures?: number;
+  numOtherFailures?: number;
 }
 
 export interface HideRepliesTwitterRequest {


### PR DESCRIPTION
This is largely identical to PR #8. We also:

* Add logic to remove duplicate user IDs in `getTwitterUsersInReport()`
* Modify `DropdownButtonComponent` to emit when an action is selected. We use
this to update the action card text when block or mute are selected.