### PR TITLE
Add development build to angular.json and update build:app:dev command

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -40,6 +40,14 @@
             "scripts": []
           },
           "configurations": {
+            "development": {
+              "optimization": false,
+              "sourceMap": true,
+              "namedChunks": true,
+              "extractLicenses": false,
+              "vendorChunk": true,
+              "buildOptimizer": false
+            },
             "production": {
               "fileReplacements": [
                 {
@@ -65,10 +73,14 @@
             "proxyConfig": "proxy.conf.js"
           },
           "configurations": {
+            "development": {
+              "browserTarget": "harassment-manager:build:development"
+            },
             "production": {
               "browserTarget": "harassment-manager:build:production"
             }
-          }
+          },
+          "defaultConfiguration": "development"
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build:all:dev": "npm run build:app:dev && npm run build:server",
     "build:all:prod": "npm run build:app:prod && npm run build:server",
-    "build:app:dev": "ng build",
+    "build:app:dev": "ng build --configuration development",
     "build:app:prod": "ng build --configuration production",
     "build:server": "tsc -p src/tsconfig.server.json",
     "check-format": "gts check",


### PR DESCRIPTION
Angular 12 changed `ng build` to use the "production" configuration by default, which doesn't create source maps (used for debugging in the browser). We add that configuration and change the corresponding build command.