### PR TITLE
Add support for Twitter API v2 Full-Archive Search

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -15,3 +15,6 @@
 
 # Node.js dependencies:
 node_modules/
+
+# Miscellaneous
+.angular/cache

--- a/app.yaml
+++ b/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: nodejs10
+runtime: nodejs12
 service: default
 instance_class: F4_1G
 
@@ -25,7 +25,7 @@ automatic_scaling:
 
 # Required for min_idle_instances!
 inbound_services:
-- warmup
+  - warmup
 
 env_variables:
   NODE_ENV: production

--- a/docs/1_setup.md
+++ b/docs/1_setup.md
@@ -70,8 +70,9 @@ for more details. You may also see minute differences in:
   timestamp format each API supports (YYYYMMDD for Enterprise and
   YYYY-MM-DDTHH:mm:ssZ for v2).
 - The order the tweets are displayed when sorted by "Priority". This is due to
-  small differences in how the APIs return the tweet text, which causes some
-  variation in the Perspective API scores for the text.
+  small differences in how we parse out the tweet text, which causes some
+  variation in the Perspective API scores for the text. See issue #19 for more
+  details.
 
 ## 2. Create a Google Cloud Platform (GCP) project
 

--- a/docs/1_setup.md
+++ b/docs/1_setup.md
@@ -18,40 +18,60 @@ of developers.
 
 ## 1. Get access to Twitter APIs
 
-**NOTE: The full suite of Twitter APIs the app uses require additional access
-beyond the default Twitter API [Essential access
-level](https://developer.twitter.com/en/docs/twitter-api/getting-started/about-twitter-api).
-The [Enterprise
-search](https://developer.twitter.com/en/docs/twitter-api/enterprise/search-api/overview)
-additionally requires an [enterprise
-account](https://developer.twitter.com/en/docs/twitter-api/enterprise/search-api/overview).**
-
-**NOTE: We plan to migrate the Enterprise Full-Archive Search API to the v2 Search Tweets
-in the future. We will update this documentation accordingly.**
-
 The app makes use of several Twitter APIs, including:
 
-- [The Enterprise Full-Archive Search
-  API](https://developer.twitter.com/en/docs/twitter-api/enterprise/search-api/overview) to fetch
-  tweets directed at the logged in user
-- The v2 [blocks](https://developer.twitter.com/en/docs/twitter-api/users/blocks/introduction)
+- The [Enterprise Full-Archive Search
+  API](https://developer.twitter.com/en/docs/twitter-api/enterprise/search-api/overview)
+  **or** the [v2 Full-Archive Search
+  endpoint](https://developer.twitter.com/en/docs/twitter-api/tweets/search/quick-start/full-archive-search)
+  to fetch tweets directed at the logged in user
+- The v2
+  [blocks](https://developer.twitter.com/en/docs/twitter-api/users/blocks/introduction)
   endpoint to block users on behalf of the authenticated user
-- The v2 [mutes](https://developer.twitter.com/en/docs/twitter-api/users/mutes/introduction)
+- The v2
+  [mutes](https://developer.twitter.com/en/docs/twitter-api/users/mutes/introduction)
   endpoint to mute users on behalf of the authenticated user
 - The v2 [hide
   replies](https://developer.twitter.com/en/docs/twitter-api/tweets/hide-replies/introduction)
   endpoint to hide replies on behalf of the authenticated user
 
 To support all this functionality, you'll need to [get access to the Twitter
-API](https://developer.twitter.com/en/docs/twitter-api/getting-started/getting-access-to-the-twitter-api)
-and the Enterprise Full-Archive Search API.
+API](https://developer.twitter.com/en/docs/twitter-api/getting-started/getting-access-to-the-twitter-api).
 
-Once granted, take note of the:
+**NOTE: The full suite of Twitter APIs the app uses require additional access
+beyond the default Twitter API [Essential access
+level](https://developer.twitter.com/en/docs/twitter-api/getting-started/about-twitter-api).
+The [Enterprise
+search](https://developer.twitter.com/en/docs/twitter-api/enterprise/search-api/overview)
+API requires an [enterprise
+account](https://developer.twitter.com/en/docs/twitter-api/enterprise/search-api/overview),
+while v2 Full-Archive Search requires [academic
+access](https://developer.twitter.com/en/products/twitter-api/academic-research).**
+
+Once granted access, take note of the:
 
 - Account name, app key, and app secret for your Twitter API developer account
-- Username and password for your Enterpise Full-Archive Search API account
+- If using the Enterprise Full-Archive Search API, the Username and password for
+  your enterprise account
+- If using the v2 Full-Archive Search endpoint, the Twitter bearer token for
+  your app
 
-You'll need both sets of credentials later on.
+You'll need these credentials later on.
+
+### Enterprise Full-Archive Search vs. v2 Full-Archive Search
+
+The tool is implemented in a way that either API can be used. While both APIs
+offer similar functionality, there are key differences in rate limits. We refer
+users to [Twitter's
+comparison](https://developer.twitter.com/en/docs/twitter-api/tweets/search/migrate)
+for more details. You may also see minute differences in:
+
+- Which tweets are fetched. This is due to differences in granularity for
+  timestamp format each API supports (YYYYMMDD for Enterprise and
+  YYYY-MM-DDTHH:mm:ssZ for v2).
+- The order the tweets are displayed when sorted by "Priority". This is due to
+  small differences in how the APIs return the tweet text, which causes some
+  variation in the Perspective API scores for the text.
 
 ## 2. Create a Google Cloud Platform (GCP) project
 

--- a/docs/2_development.md
+++ b/docs/2_development.md
@@ -145,9 +145,6 @@ The required fields are:
   be the server-side key created in [setup](1_setup.md) in GCP
   [Credentials](https://console.cloud.google.com/apis/credentials)
 - `cloudProjectId`: Your Google Cloud project ID
-
-The optional fields are:
-
 - `twitterApiCredentials`: Your credentials for the Twitter APIs.
 
 All together, your config should look something like one of the two configs

--- a/docs/2_development.md
+++ b/docs/2_development.md
@@ -145,7 +145,11 @@ The required fields are:
   be the server-side key created in [setup](1_setup.md) in GCP
   [Credentials](https://console.cloud.google.com/apis/credentials)
 - `cloudProjectId`: Your Google Cloud project ID
-- `twitterApiCredentials`: Your credentials for the Twitter APIs.
+- `twitterApiCredentials`: Your credentials for the Twitter APIs. For Enterprise
+  Full-Archive search, Twitter will provide you with the credentials. All other
+  API credentials should be available on the Twitter [Developer
+  Portal](https://developer.twitter.com/portal) under "Keys and Tokens" for your
+  app and project.
 
 All together, your config should look something like one of the two configs
 below, with the relevant credentials and key values replaced.
@@ -170,7 +174,7 @@ below, with the relevant credentials and key values replaced.
 
 ### If using the v2 Full-Archive Search endpoint:
 
-````json
+```json
 {
   "port": "3000",
   "staticPath": "dist/harassment-manager",
@@ -182,6 +186,7 @@ below, with the relevant credentials and key values replaced.
     "bearerToken": "{TWITTER_APP_BEARER_TOKEN}"
   }
 }
+```
 
 ## 7. (Optional) Enable Google Analytics
 
@@ -203,7 +208,7 @@ To build and run the app and a local development server, run
 
 ```shell
 npm run build:all:dev && npm run start:dev-server
-````
+```
 
 To build and run the app and a local production server, run
 
@@ -237,3 +242,7 @@ We maintain a [CircleCI](https://circleci.com/) configuration in
 is pushed to this GitHub repository. You can choose to use the same
 configuration for your own CircleCI setup if you'd like or remove the
 configuration in favor of another CI solution or none at all.
+
+```
+
+```

--- a/docs/2_development.md
+++ b/docs/2_development.md
@@ -148,13 +148,12 @@ The required fields are:
 
 The optional fields are:
 
-- `twitterApiCredentials`: Your credentials for the Twitter APIs. The server
-  expect this field to be an object with `accountName`, `username`, and
-  `password` fields for the Enterprise Search API and `appKey` and `appToken`
-  for the Standard API.
+- `twitterApiCredentials`: Your credentials for the Twitter APIs.
 
-All together, your config should look something like the config below, with the
-relevant credentials and key values replaced.
+All together, your config should look something like one of the two configs
+below, with the relevant credentials and key values replaced.
+
+### If using the Enteprise Full-Archive Search API:
 
 ```json
 {
@@ -166,11 +165,26 @@ relevant credentials and key values replaced.
     "accountName": "{TWITTER_API_ACCOUNT_NAME}",
     "username": "{TWITTER_API_USERNAME}",
     "password": "{TWITTER_API_PASSWORD}",
-    "appKey": "{APP_KEY}",
-    "appToken": "{APP_TOKEN}"
+    "appKey": "{TWITTER_APP_KEY}",
+    "appToken": "{TWITTER_APP_TOKEN}"
   }
 }
 ```
+
+### If using the v2 Full-Archive Search endpoint:
+
+````json
+{
+  "port": "3000",
+  "staticPath": "dist/harassment-manager",
+  "googleCloudApiKey": "{YOUR_GOOGLE_CLOUD_API_KEY}",
+  "cloudProjectId": "{YOUR_GOOGLE_CLOUD_PROJECTID}",
+  "twitterApiCredentials": {
+    "appKey": "{TWITTER_APP_KEY}",
+    "appToken": "{TWITTER_APP_TOKEN}",
+    "bearerToken": "{TWITTER_APP_BEARER_TOKEN}"
+  }
+}
 
 ## 7. (Optional) Enable Google Analytics
 
@@ -192,7 +206,7 @@ To build and run the app and a local development server, run
 
 ```shell
 npm run build:all:dev && npm run start:dev-server
-```
+````
 
 To build and run the app and a local production server, run
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "@types/jasmine": "^3.10.3",
         "@types/jasminewd2": "~2.0.10",
         "@types/jspdf": "^1.3.3",
-        "@types/node": "^17.0.21",
+        "@types/node": "17.0.10",
         "@types/supertest": "^2.0.11",
         "@typescript-eslint/eslint-plugin": "5.14.0",
         "@typescript-eslint/parser": "5.14.0",
@@ -6000,9 +6000,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
+      "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -29138,9 +29138,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
+      "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@types/jasmine": "^3.10.3",
     "@types/jasminewd2": "~2.0.10",
     "@types/jspdf": "^1.3.3",
-    "@types/node": "^17.0.21",
+    "@types/node": "17.0.10",
     "@types/supertest": "^2.0.11",
     "@typescript-eslint/eslint-plugin": "5.14.0",
     "@typescript-eslint/parser": "5.14.0",

--- a/src/app/social-media-item.service.ts
+++ b/src/app/social-media-item.service.ts
@@ -126,11 +126,11 @@ export class SocialMediaItemService {
   ): Observable<Tweet[]> {
     return from(
       this.twitterApiService.getTweets({
-        fromDate: formatTimestamp(startDateTimeMs),
+        startDateTimeMs,
         // Subtract 1 minute from the end time because the Twitter API
         // sometimes returns an error if we request data for the most recent
         // minute of time.
-        toDate: formatTimestamp(endDateTimeMs - 60000),
+        endDateTimeMs: endDateTimeMs - 60000,
       })
     ).pipe(map((response: GetTweetsResponse) => response.tweets));
   }
@@ -165,23 +165,4 @@ export class SocialMediaItemService {
       )
       .pipe(map(scores => ({ item, scores })));
   }
-}
-
-// Format a millisecond-based timestamp into a date format suitable for the
-// Twitter API, as defined in:
-// https://developer.twitter.com/en/docs/tweets/search/api-reference/enterprise-search
-function formatTimestamp(ms: number): string {
-  const date = new Date(ms);
-  const MM = date.getUTCMonth() + 1; // getMonth() is zero-based
-  const dd = date.getUTCDate();
-  const hh = date.getUTCHours();
-  const mm = date.getUTCMinutes();
-
-  return (
-    `${date.getFullYear()}` +
-    `${(MM > 9 ? '' : '0') + MM}` +
-    `${(dd > 9 ? '' : '0') + dd}` +
-    `${(hh > 9 ? '' : '0') + hh}` +
-    `${(mm > 9 ? '' : '0') + mm}`
-  );
 }

--- a/src/app/social-media-item.service.ts
+++ b/src/app/social-media-item.service.ts
@@ -127,9 +127,9 @@ export class SocialMediaItemService {
     return from(
       this.twitterApiService.getTweets({
         startDateTimeMs,
-        // Subtract 1 minute from the end time because the Twitter API
-        // sometimes returns an error if we request data for the most recent
-        // minute of time.
+        // Subtract 1 minute from the end time because the Twitter API sometimes
+        // returns an error if we request data for the most recent minute of
+        // time.
         endDateTimeMs: endDateTimeMs - 60000,
       })
     ).pipe(map((response: GetTweetsResponse) => response.tweets));

--- a/src/app/test_constants.ts
+++ b/src/app/test_constants.ts
@@ -37,7 +37,6 @@ export const TWITTER_ENTRIES: Array<ScoredItem<Tweet>> = [
         user_mentions: [],
       },
       extended_tweet: {
-        display_text_range: [0, 279],
         entities: {
           hashtags: [
             {
@@ -110,7 +109,6 @@ export const TWITTER_ENTRIES: Array<ScoredItem<Tweet>> = [
         user_mentions: [],
       },
       extended_tweet: {
-        display_text_range: [0, 213],
         entities: {
           hashtags: [
             {
@@ -189,7 +187,6 @@ export const TWITTER_ENTRIES: Array<ScoredItem<Tweet>> = [
         ],
       },
       extended_tweet: {
-        display_text_range: [0, 203],
         entities: {
           hashtags: [],
           symbols: [],
@@ -274,7 +271,6 @@ export const TWITTER_ENTRIES: Array<ScoredItem<Tweet>> = [
         user_mentions: [],
       },
       extended_tweet: {
-        display_text_range: [0, 274],
         entities: {
           hashtags: [],
           symbols: [],

--- a/src/app/tweet-image/tweet-image.component.html
+++ b/src/app/tweet-image/tweet-image.component.html
@@ -16,7 +16,7 @@
 
 <ng-container *ngIf="tweet && thumbnail">
   <span class="image-thumbnail"
-        *ngIf="tweet.extended_entities && tweet.extended_entities.media">
+        *ngIf="tweet.extended_entities?.media?.length">
     <img [class.blur]="shouldBlur"
          [src]="tweet.extended_entities.media[0].media_url" [alt]="shouldBlur ? 'Blurred image from tweet.' : 'Image from tweet.'">
   </span>
@@ -24,9 +24,9 @@
 <ng-container *ngIf="tweet && !thumbnail">
   <div class="full-image"
        [class.collapsed]="collapsed"
-       *ngIf="tweet.extended_entities && tweet.extended_entities.media">
+       *ngIf="tweet.extended_entities?.media?.length">
     <img *ngFor="let media of tweet.extended_entities.media"
-        [class.blur]="shouldBlur" 
+        [class.blur]="shouldBlur"
         [src]="media.media_url" [alt]="shouldBlur ? 'Blurred image from tweet.' : 'Image from tweet.'">
   </div>
 </ng-container>

--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -128,6 +128,8 @@ export interface TwitterApiResponse {
   results: TweetObject[];
 }
 
+// Tweet object format returned by the Enterprise Twitter API.
+//
 // From twitter documentation: When ingesting Tweet data the main object is the
 // Tweet Object, which is a parent object to several child objects. For
 // example, all Tweets include a User object that describes who authored the
@@ -167,17 +169,29 @@ export interface TweetObject {
   source?: string;
 }
 
+// Tweet object format returned by the v2 Twitter API.
+//
+// See
+// https://developer.twitter.com/en/docs/twitter-api/data-dictionary/introduction
+// for more details.
 export interface V2TweetObject {
-  attachments: V2Attachments;
+  attachments?: V2Attachments;
   author_id: string;
   created_at: string;
-  entities: V2Entities;
+  entities?: V2Entities;
   id: string;
   lang: string;
   public_metrics: V2PublicMetrics;
-  referenced_tweets: V2ReferencedTweet[];
-  source: string;
+  referenced_tweets?: V2ReferencedTweet[];
+  source?: string;
   text: string;
+}
+
+interface V2Entities {
+  hashtags?: V2Hashtags[];
+  mentions?: V2Mentions[];
+  referenced_tweets?: V2ReferencedTweet[];
+  urls?: V2Url[];
 }
 
 interface V2PublicMetrics {
@@ -192,13 +206,6 @@ interface V2ReferencedTweet {
   type: string;
 }
 
-interface V2Entities {
-  hashtags?: V2Hashtags[];
-  mentions?: V2Mentions[];
-  referenced_tweets?: V2ReferencedTweet[];
-  urls?: V2Url[];
-}
-
 interface V2Mentions {
   start: number;
   end: number;
@@ -206,7 +213,7 @@ interface V2Mentions {
   id: string;
 }
 
-interface V2Hashtags {
+export interface V2Hashtags {
   start: number;
   end: number;
   tag: string;
@@ -241,7 +248,6 @@ interface V2Attachments {
   media_keys: string[];
 }
 
-// TODO: Maybe remove all unused fields?
 export interface TwitterUser {
   id_str: string;
   screen_name: string;

--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -153,7 +153,6 @@ export interface TweetObject {
   // directed to the extended_entities section.
   entities?: TweetEntities;
 
-  display_text_range?: number[];
   truncated?: boolean;
   extended_tweet?: ExtendedTweet;
 
@@ -323,7 +322,6 @@ export interface TweetHashtag {
 // For tweets above 140 characters.
 interface ExtendedTweet {
   full_text: string;
-  display_text_range: number[];
   entities: TweetEntities;
 }
 

--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -79,8 +79,8 @@ export interface CreatePdfResponse {
 export interface GetTweetsRequest {
   credentials?: firebase.auth.UserCredential;
   nextPageToken?: string;
-  fromDate: string; // yyyymmddhhmm format is expected here.
-  toDate: string; // yyyymmddhhmm format is expected here.
+  startDateTimeMs: number;
+  endDateTimeMs: number;
 }
 
 export interface GetTweetsResponse {
@@ -125,14 +125,7 @@ export interface HideRepliesTwitterResponse {
 
 export interface TwitterApiResponse {
   next: string;
-  requestParameters: TwitterApiRequestParams;
   results: TweetObject[];
-}
-
-interface TwitterApiRequestParams {
-  fromDate: string;
-  toDate: string;
-  maxResults: number;
 }
 
 // From twitter documentation: When ingesting Tweet data the main object is the
@@ -174,6 +167,81 @@ export interface TweetObject {
   source?: string;
 }
 
+export interface V2TweetObject {
+  attachments: V2Attachments;
+  author_id: string;
+  created_at: string;
+  entities: V2Entities;
+  id: string;
+  lang: string;
+  public_metrics: V2PublicMetrics;
+  referenced_tweets: V2ReferencedTweet[];
+  source: string;
+  text: string;
+}
+
+interface V2PublicMetrics {
+  like_count: number;
+  quote_count: number;
+  reply_count: number;
+  retweet_count: number;
+}
+
+interface V2ReferencedTweet {
+  id: string;
+  type: string;
+}
+
+interface V2Entities {
+  hashtags?: V2Hashtags[];
+  mentions?: V2Mentions[];
+  referenced_tweets?: V2ReferencedTweet[];
+  urls?: V2Url[];
+}
+
+interface V2Mentions {
+  start: number;
+  end: number;
+  username: string;
+  id: string;
+}
+
+interface V2Hashtags {
+  start: number;
+  end: number;
+  tag: string;
+}
+
+interface V2Url {
+  display_url: string;
+  extended_url: string;
+  start: number;
+  end: number;
+}
+
+export interface V2Includes {
+  media?: V2Media[];
+  users?: V2Users[];
+}
+
+interface V2Media {
+  media_key: string;
+  type: string;
+  url: string;
+}
+
+interface V2Users {
+  profile_image_url: string;
+  name: string;
+  username: string;
+  verified: boolean;
+  id: string;
+}
+interface V2Attachments {
+  media_keys: string[];
+}
+
+// TODO: Maybe remove all unused fields?
 export interface TwitterUser {
   id_str: string;
   screen_name: string;
@@ -206,7 +274,7 @@ interface Symbols {
   text: string;
 }
 
-interface TweetUserMention {
+export interface TweetUserMention {
   id?: number;
   id_str?: string;
   indices: Indices;
@@ -214,7 +282,7 @@ interface TweetUserMention {
   screen_name: string;
 }
 
-interface TweetMedia {
+export interface TweetMedia {
   id_str?: string;
   media_url: string;
   type: string;
@@ -234,7 +302,7 @@ interface TweetMediaDimensions {
   resize: string;
 }
 
-interface TweetUrl {
+export interface TweetUrl {
   display_url?: string;
   expanded_url?: string;
   indices: Indices;

--- a/src/server/middleware/twitter.middleware.ts
+++ b/src/server/middleware/twitter.middleware.ts
@@ -298,8 +298,8 @@ function loadTwitterData(
   }
 
   const auth: AxiosBasicCredentials = {
-    username: credentials!.username,
-    password: credentials!.password,
+    username: credentials.username!,
+    password: credentials.password!,
   };
 
   return axios

--- a/src/server/server_config.template.json
+++ b/src/server/server_config.template.json
@@ -6,6 +6,9 @@
   "twitterApiCredentials": {
     "accountName": "",
     "username": "",
-    "password": ""
+    "password": "",
+    "appKey": "",
+    "appToken": "",
+    "bearerToken": ""
   }
 }

--- a/src/server/serving.ts
+++ b/src/server/serving.ts
@@ -72,12 +72,17 @@ export interface Config {
 }
 
 export interface TwitterApiCredentials {
-  accountName: string;
+  // The below three fields are necessary if using Enterprise Full-Archive
+  // Search.
+  accountName?: string;
+  password?: string;
+  username?: string;
+  // The below two fields are necessary for the Blocks, Mutes, and Hide Replies
+  // APIs.
   appKey: string;
   appToken: string;
+  // Necessary if using v2 Full-Archive Search.
   bearerToken?: string;
-  password: string;
-  username: string;
 }
 
 export interface WebAppCredentials {

--- a/src/server/serving.ts
+++ b/src/server/serving.ts
@@ -75,6 +75,7 @@ export interface TwitterApiCredentials {
   accountName: string;
   appKey: string;
   appToken: string;
+  bearerToken?: string;
   password: string;
   username: string;
 }


### PR DESCRIPTION
As-is, Harassment Manager leverages the Enterprise Full-Archive Search API to fetch tweets directed at the logged-in user. This change enables developers to use either Enterprise or Twitter API v2 Full-Archive Search, which is the latest version of the Twitter API.

To implement this, we add the relevant request logic to `twitter.middleware.ts`. We "pack" the v2 response format into the Enterprise response format to enable developers to switch between Enterprise and v2 forwards and backwards, without breaking usage for existing users of the application.

Additional changes include:

- Removing unused types and defining new ones for the v2 format
- Changing `fromDate` and `toDate` to `startDateTimeMs` and `endDateTimeMs` and using formatting functions to accommodate differences in the timestamps expected by Enterprise vs. v2
- Modifying `server_config_template.json` with a `bearerToken` field, which is necessary for using v2 Full-Archive Search
- Updating the AppEngine runtime to `nodejs12` to support some new operators, like `flatMap`
- Updating documentation

We deployed and tested an instance of Harassment Manager with each API and the application's behavior is largely identical between both versions, with a couple minor differences:

1. The APIs return slightly different sets of tweets because of differences in the granularity of the timestamp format expected by each API. This difference is usually no more than an additional 1-3 tweets in the v2 instance.
2. The tweets are displayed in slightly different orders when sorted by "Priority". This is due to small differences in how we parse the tweet text, which causes some variation in the Perspective API scores for the text. We opened issue #19 to investigate.

We also noticed the Enterprise instance does not render some images that the v2 instance does. This seems more like an implementation issue on our end, rather than an API difference. We opened issue #17 to investigate.