### PR TITLE
ft/twitter-api-automation

### DIFF
--- a/docs/2_development.md
+++ b/docs/2_development.md
@@ -189,6 +189,7 @@ below, with the relevant credentials and key values replaced.
   }
 }
 ```
+
 ### If using the v2 Essential or Elevated API:
 
 ```json

--- a/docs/2_development.md
+++ b/docs/2_development.md
@@ -185,6 +185,22 @@ below, with the relevant credentials and key values replaced.
     "appKey": "{TWITTER_APP_KEY}",
     "appToken": "{TWITTER_APP_TOKEN}",
     "bearerToken": "{TWITTER_APP_BEARER_TOKEN}",
+    "useEssentialOrElevatedV2": false
+  }
+}
+```
+### If using the v2 Essential or Elevated API:
+
+```json
+{
+  "port": "3000",
+  "staticPath": "dist/harassment-manager",
+  "googleCloudApiKey": "{YOUR_GOOGLE_CLOUD_API_KEY}",
+  "cloudProjectId": "{YOUR_GOOGLE_CLOUD_PROJECTID}",
+  "twitterApiCredentials": {
+    "appKey": "{TWITTER_APP_KEY}",
+    "appToken": "{TWITTER_APP_TOKEN}",
+    "bearerToken": "{TWITTER_APP_BEARER_TOKEN}",
     "useEssentialOrElevatedV2": true
   }
 }

--- a/docs/2_development.md
+++ b/docs/2_development.md
@@ -167,7 +167,8 @@ below, with the relevant credentials and key values replaced.
     "username": "{TWITTER_API_USERNAME}",
     "password": "{TWITTER_API_PASSWORD}",
     "appKey": "{TWITTER_APP_KEY}",
-    "appToken": "{TWITTER_APP_TOKEN}"
+    "appToken": "{TWITTER_APP_TOKEN}",
+    "useEssentialOrElevatedV2": false
   }
 }
 ```
@@ -183,7 +184,8 @@ below, with the relevant credentials and key values replaced.
   "twitterApiCredentials": {
     "appKey": "{TWITTER_APP_KEY}",
     "appToken": "{TWITTER_APP_TOKEN}",
-    "bearerToken": "{TWITTER_APP_BEARER_TOKEN}"
+    "bearerToken": "{TWITTER_APP_BEARER_TOKEN}",
+    "useEssentialOrElevatedV2": true
   }
 }
 ```

--- a/proxy.conf.js
+++ b/proxy.conf.js
@@ -25,6 +25,7 @@ const PROXY_CONFIG = [
       '/hide_replies_twitter',
       '/mute_twitter_users',
       '/save_twitter_report_csv',
+      '/get_twitter_api_version',
     ],
     target: 'http://localhost:3000',
     secure: false,

--- a/src/app/create-report/create-report.component.ts
+++ b/src/app/create-report/create-report.component.ts
@@ -164,8 +164,8 @@ export class CreateReportComponent implements OnInit, AfterViewInit {
 
   overlayScrollStrategy: ScrollStrategy;
 
-  // Twitter Api Version
-  useEssentialOrElevatedV2 = false
+  // Twitter API Version
+  useEssentialOrElevatedV2 = false;
   
 
   // This describes how the overlay should be connected to the origin element.
@@ -731,9 +731,9 @@ export class CreateReportComponent implements OnInit, AfterViewInit {
     if (selection.customOption) {
       this.getCustomDateFilter();
     } else if (selection.numDays) {
-      const  filterType: DayFilterType = this.useEssentialOrElevatedV2? DayFilterType.NOW : DayFilterType.MIDNIGHT;
+      const filterType: DayFilterType = this.useEssentialOrElevatedV2 ? DayFilterType.NOW : DayFilterType.MIDNIGHT;
       this.dateFilterService.updateFilter( 
-        buildDateFilterForNDays(this.now, selection.numDays, filterType )
+        buildDateFilterForNDays(this.now, selection.numDays, filterType)
       );
     }
   }

--- a/src/app/create-report/create-report.component.ts
+++ b/src/app/create-report/create-report.component.ts
@@ -60,6 +60,7 @@ import {
   applyCommentFilters,
   buildDateFilterForNDays,
   DateFilter,
+  DayFilterType,
   ToxicityRangeFilter,
 } from '../filter_utils';
 import {

--- a/src/app/create-report/create-report.component.ts
+++ b/src/app/create-report/create-report.component.ts
@@ -731,7 +731,7 @@ export class CreateReportComponent implements OnInit, AfterViewInit {
     if (selection.customOption) {
       this.getCustomDateFilter();
     } else if (selection.numDays) {
-      const  filterType:DayFilterType = this.useEssentialOrElevatedV2? DayFilterType.NOW : DayFilterType.MIDNIGHT;
+      const  filterType: DayFilterType = this.useEssentialOrElevatedV2? DayFilterType.NOW : DayFilterType.MIDNIGHT;
       this.dateFilterService.updateFilter( 
         buildDateFilterForNDays(this.now, selection.numDays, filterType )
       );

--- a/src/app/create-report/create-report.component.ts
+++ b/src/app/create-report/create-report.component.ts
@@ -261,8 +261,6 @@ export class CreateReportComponent implements OnInit, AfterViewInit {
     { displayText: DateFilterName.LAST_WEEK, numDays: 7 },
     { displayText: DateFilterName.LAST_MONTH, numDays: 31 },
     { displayText: DateFilterName.CUSTOM, customOption: true },
-    { displayText: DateFilterName.LAST_MONTH, numDays: 31 },
-    { displayText: DateFilterName.CUSTOM, customOption: true },
   ];
 
   essentialDateDropdownOptions: DateFilterDropdownOption[] = [

--- a/src/app/filter_utils.ts
+++ b/src/app/filter_utils.ts
@@ -141,7 +141,9 @@ const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
 // of yesterday (midnight yesterday), but this could be interpreted 
 // differently. We're also interpreting weeks and months relative to today, 
 // but these could also be determined based on where we are in the month.
-// Added an optional filterType parameter to allow for the option of using the current time as the start time instead of midnight.
+// 
+// The optional filterType parameter allows for the option of using the
+// current time as the start time, instead of midnight.
 export function buildDateFilterForNDays(now: Date, days: number, fromFilter: DayFilterType = DayFilterType.MIDNIGHT): DateFilter {
   const fromTime = fromFilter === DayFilterType.NOW ? now.getTime() : new Date(now).setHours(0, 0, 0, 0);
 

--- a/src/app/filter_utils.ts
+++ b/src/app/filter_utils.ts
@@ -37,6 +37,10 @@ export interface ToxicityRangeFilter {
   includeUnscored: boolean;
 }
 
+export enum DayFilterType {
+  NOW,
+  MIDNIGHT
+}
 /**
  * Applies the regex, date, and threshold filters to the specified comments, and
  * returns the subset of comments that match the filters.
@@ -137,10 +141,13 @@ const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
 // of yesterday (midnight yesterday), but this could be interpreted 
 // differently. We're also interpreting weeks and months relative to today, 
 // but these could also be determined based on where we are in the month.
-export function buildDateFilterForNDays(now: Date, days: number): DateFilter {
-  const midnightToday = new Date(now).setHours(0, 0, 0, 0);
+// Added an optional filterType parameter to allow for the option of using the current time as the start time instead of midnight.
+export function buildDateFilterForNDays(now: Date, days: number, fromFilter: DayFilterType = DayFilterType.MIDNIGHT): DateFilter {
+
+  const fromTime = fromFilter === DayFilterType.NOW ? now.getTime() : new Date(now).setHours(0, 0, 0, 0);
+
   return {
-    startDateTimeMs: midnightToday - days * MILLISECONDS_PER_DAY,
+    startDateTimeMs: fromTime - days * MILLISECONDS_PER_DAY,
     endDateTimeMs: now.getTime(),
   };
 }

--- a/src/app/filter_utils.ts
+++ b/src/app/filter_utils.ts
@@ -143,7 +143,6 @@ const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
 // but these could also be determined based on where we are in the month.
 // Added an optional filterType parameter to allow for the option of using the current time as the start time instead of midnight.
 export function buildDateFilterForNDays(now: Date, days: number, fromFilter: DayFilterType = DayFilterType.MIDNIGHT): DateFilter {
-
   const fromTime = fromFilter === DayFilterType.NOW ? now.getTime() : new Date(now).setHours(0, 0, 0, 0);
 
   return {

--- a/src/app/social-media-item.service.ts
+++ b/src/app/social-media-item.service.ts
@@ -30,6 +30,7 @@ import {
   ScoredItem,
   SocialMediaItem,
   Tweet,
+  TwitterApiVersion,
 } from 'src/common-types';
 import { stripOutEntitiesFromItemText } from './common/social_media_item_utils';
 import { OauthApiService } from './oauth_api.service';
@@ -133,6 +134,10 @@ export class SocialMediaItemService {
         endDateTimeMs: endDateTimeMs - 60000,
       })
     ).pipe(map((response: GetTweetsResponse) => response.tweets));
+  }
+
+  getTwitterApiVersion(): Observable<TwitterApiVersion>{
+    return this.twitterApiService.getTwitterApiVersion().pipe(map(response=>response.version));
   }
 
   private scoreItems(

--- a/src/app/twitter_api.service.ts
+++ b/src/app/twitter_api.service.ts
@@ -28,6 +28,7 @@ import {
   HideRepliesTwitterResponse,
   MuteTwitterUsersRequest,
   MuteTwitterUsersResponse,
+  TwitterApiVersionResponse,
   TwitterUser,
 } from '../common-types';
 import { OauthApiService } from './oauth_api.service';
@@ -155,5 +156,13 @@ export class TwitterApiService {
         headers,
       })
       .pipe(take(1));
+  }
+
+  getTwitterApiVersion(): Observable<TwitterApiVersionResponse> {
+    const headers = new HttpHeaders();
+    headers.append('Content-Type', 'application/json');
+    return this.httpClient.get<TwitterApiVersionResponse>('/get_twitter_api_version', {
+      headers,
+    }).pipe(take(1));
   }
 }

--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -360,3 +360,13 @@ export interface ClearReportRequest {
   idToken: string;
   platform: Platform;
 }
+
+export enum TwitterApiVersion {
+  ESSENTIAL_OR_ELEVATED_V2 = 'essentialOrElevatedV2',
+  ENTERPRISE = 'enterprise',
+}
+
+export interface TwitterApiVersionResponse {
+  version: TwitterApiVersion;
+}
+

--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -362,8 +362,8 @@ export interface ClearReportRequest {
 }
 
 export enum TwitterApiVersion {
-  ESSENTIAL_OR_ELEVATED_V2 = 'essentialOrElevatedV2',
-  ENTERPRISE = 'enterprise',
+  ESSENTIAL_OR_ELEVATED_V2,
+  ENTERPRISE,
 }
 
 export interface TwitterApiVersionResponse {

--- a/src/server/server_config.template.json
+++ b/src/server/server_config.template.json
@@ -9,6 +9,7 @@
     "password": "",
     "appKey": "",
     "appToken": "",
-    "bearerToken": ""
+    "bearerToken": "",
+    "useEssentialOrElevatedV2": false
   }
 }

--- a/src/server/serving.ts
+++ b/src/server/serving.ts
@@ -30,6 +30,8 @@ import {
   CreateSpreadsheetRequest,
   isFirebaseCredential,
   Tweet,
+  TwitterApiVersion,
+  TwitterApiVersionResponse
 } from '../common-types';
 import * as dev from '../environments/environment';
 import * as prod from '../environments/environment.prod';
@@ -83,6 +85,9 @@ export interface TwitterApiCredentials {
   appToken: string;
   // Necessary if using v2 Full-Archive Search.
   bearerToken?: string;
+
+  // Flag to indicate whether to use the  Essential or Academic v2 Full-Archive Search API
+  useEssentialOrElevatedV2?: boolean;
 }
 
 export interface WebAppCredentials {
@@ -167,6 +172,15 @@ export class Server {
     // Google AppEngine and ComputeEngine
     this.app.get('/_ah/health', (_req, res) => {
       res.status(200).send('ok');
+    });
+
+    // get Twitter API Version
+    this.app.get('/get_twitter_api_version', (_req, res) => {
+      const version = this.config.twitterApiCredentials.useEssentialOrElevatedV2 ? TwitterApiVersion.ESSENTIAL_OR_ELEVATED_V2 : TwitterApiVersion.ENTERPRISE;
+      const response:TwitterApiVersionResponse = {
+        version: version
+      }
+      res.status(200).send(response);
     });
 
     this.app.post('/check', (req, res) => {

--- a/src/server/serving.ts
+++ b/src/server/serving.ts
@@ -85,7 +85,6 @@ export interface TwitterApiCredentials {
   appToken: string;
   // Necessary if using v2 Full-Archive Search.
   bearerToken?: string;
-
   // Flag to indicate whether to use the  Essential or Academic v2 Full-Archive Search API
   useEssentialOrElevatedV2?: boolean;
 }

--- a/src/server/serving.ts
+++ b/src/server/serving.ts
@@ -175,7 +175,6 @@ export class Server {
       res.status(200).send('ok');
     });
 
-    // get Twitter API Version
     this.app.get('/get_twitter_api_version', (_req, res) => {
       const version = this.config.twitterApiCredentials.useEssentialOrElevatedV2 ? TwitterApiVersion.ESSENTIAL_OR_ELEVATED_V2 : TwitterApiVersion.ENTERPRISE;
       const response:TwitterApiVersionResponse = {

--- a/src/server/serving.ts
+++ b/src/server/serving.ts
@@ -85,7 +85,9 @@ export interface TwitterApiCredentials {
   appToken: string;
   // Necessary if using v2 Full-Archive Search.
   bearerToken?: string;
-  // Flag to indicate whether to use the  Essential or Academic v2 Full-Archive Search API
+// Flag to indicate whether to use the Essential/Elevated v2 API
+// (/2/tweets/search/recent) or Academic v2 Full-Archive Search API
+// (/2/tweets/search/all).
   useEssentialOrElevatedV2?: boolean;
 }
 

--- a/src/server/serving_test.ts
+++ b/src/server/serving_test.ts
@@ -117,6 +117,7 @@ describe('Server', () => {
         appToken: 'fake token',
         password: 'fake password',
         username: 'fake username',
+        useEssentialOrElevatedV2: false,
       },
     };
     server = new serving.Server(config);


### PR DESCRIPTION
Harassment Manager allows developers to either use Enterprise or Twitter API v2 Full-Archive Search. They however have to manually update the endpoint, batch size and date filter options to switch between either of them. This PR allows developers to switch between the two without changing much of the code.
To achieve this we introduced a flag `useEssentialOrElevatedV2` allowing developers to choose which Twitter API version they are using. This configures the rest of Harassment Manager to work with the different Twitter API's without breaking usage for existing users.